### PR TITLE
feat(menu): unify daily and standard food items in menu API

### DIFF
--- a/OrionXCanteen/backend/app.js
+++ b/OrionXCanteen/backend/app.js
@@ -8,7 +8,6 @@ import mailRouter from './routes/mailRouter.js';
 import orderRoutes from './routes/orderRoutes.js'; // Uncomment when order routes are implemented
 import foodRoutes from './routes/foodRoutes.js'; // Dynamic import for food routes
 import categoryRoute from './routes/categoryRoute.js'; // Dynamic import for category routes
-import menuRoutes from './routes/menuRoutes.js';
 import dailyFoodRoutes from './routes/dailyFoodRoutes.js';
 import dailyFoodComponentRoutes from './routes/dailyFoodComponentRoutes.js';
 
@@ -34,7 +33,7 @@ app.use('/api/foods', foodRoutes); // Dynamic import for food routes
 app.use('/api/admin',dailyFoodRoutes);
 app.use('/api/admin',dailyFoodComponentRoutes)
 app.use('/api/categories', categoryRoute); // Dynamic import for category routes
-app.use('/api/menu', menuRoutes)
+
 
 // Global error handler
 app.use((err, req, res, next) => {

--- a/OrionXCanteen/backend/controllers/customer/menuController.js
+++ b/OrionXCanteen/backend/controllers/customer/menuController.js
@@ -1,12 +1,66 @@
-import * as MenuModel from '../../models/customer/menuModel.js';
+// import * as MenuModel from '../../models/customer/menuModel.js';
+// import Food from '../../models/Food.js';
+
+// export const getDailyMenu = async (req, res) => {
+//     try {
+//         const menu = await MenuModel.findTodaysMenu();
+//         res.status(200).json(menu);
+//     } catch (error) {
+//         console.error("GET DAILY MENU FAILED:", error);
+//         res.status(500).json({ message: "Failed to retrieve the daily menu." });
+//     }
+// };
 
 
-export const getDailyMenu = async (req, res) => {
-    try {
-        const menu = await MenuModel.findTodaysMenu();
-        res.status(200).json(menu);
-    } catch (error) {
-        console.error("GET DAILY MENU FAILED:", error);
-        res.status(500).json({ message: "Failed to retrieve the daily menu." });
-    }
-};
+
+
+
+// // Controller to get meal availability for a specific date (defaults to today)
+// export const getMealAvailability = async (req, res) => {
+//     try {
+//         const date = req.query.date || new Date().toISOString().split('T')[0];
+        
+//         const availableMealTypes = await Food.getMealTypesByDate(date);
+        
+//         const availability = {
+//             breakfast: availableMealTypes.includes('breakfast'),
+//             lunch: availableMealTypes.includes('lunch'),
+//             dinner: availableMealTypes.includes('dinner')
+//         };
+        
+//         res.status(200).json({
+//             success: true,
+//             data: {
+//                 date: date,
+//                 availability
+//             }
+//         });
+//     } catch (error) {
+//         console.error('Error checking meal availability:', error);
+//         res.status(500).json({
+//             success: false,
+//             message: 'Failed to check meal availability',
+//             error: error.message
+//         });
+//     }
+// };
+
+// // Controller to get today's menu, with an optional filter by meal_type
+// export const getTodaysMenu = async (req, res) => {
+//     try {
+//         const { meal_type } = req.query; // e.g., /api/foods/today/menu?meal_type=lunch
+//         const menu = await Food.getTodaysMenu(meal_type);
+        
+//         res.status(200).json({
+//             success: true,
+//             data: menu
+//         });
+//     } catch (error) {
+//         console.error("Error fetching today's menu:", error);
+//         res.status(500).json({
+//             success: false,
+//             message: "Failed to fetch today's menu",
+//             error: error.message
+//         });
+//     }
+// };

--- a/OrionXCanteen/backend/models/Food.js
+++ b/OrionXCanteen/backend/models/Food.js
@@ -1,203 +1,53 @@
 import pool from '../config/db.js';
 
 class Food {
-  // Create a new food item
-  static async create(foodData) {
-    const connection = await pool.getConnection();
-    try {
-      await connection.beginTransaction();
-      
-      // Insert food
-      const [foodResult] = await connection.execute(
-        `INSERT INTO foods (food_id, food_name, category_id, price, available_date, meal_type, is_available, image_url) 
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        [foodData.food_id, foodData.food_name, foodData.category_id, foodData.price, 
-         foodData.available_date, foodData.meal_type, foodData.is_available, foodData.image_url]
-      );
-      
-      // Insert components if provided
-      if (foodData.components && foodData.components.length > 0) {
-        for (const component_id of foodData.components) {
-          await connection.execute(
-            `INSERT INTO daily_menu_items (food_id, component_id, available_date) 
-             VALUES (?, ?, ?)`,
-            [foodData.food_id, component_id, foodData.available_date]
-          );
-        }
-      }
-      
-      await connection.commit();
-      return foodResult;
-    } catch (error) {
-      await connection.rollback();
-      throw error;
-    } finally {
-      connection.release();
+    static async getMealTypesByDate(date) {
+        const [rows] = await pool.execute(
+            `SELECT DISTINCT meal_type FROM daily_food WHERE meal_date = ?`,
+            [date]
+        );
+        return rows.map(row => row.meal_type);
     }
-  }
 
-  // Get all food items with optional filters
-  static async findAll(filters = {}) {
-    let query = `
-      SELECT f.*, 
-             GROUP_CONCAT(DISTINCT fc.component_name SEPARATOR ', ') as components,
-             GROUP_CONCAT(DISTINCT fc.component_id SEPARATOR ', ') as component_ids
-      FROM foods f
-      LEFT JOIN daily_menu_items dmi ON f.food_id = dmi.food_id 
-      LEFT JOIN food_components fc ON dmi.component_id = fc.component_id
-    `;
-    
-    const conditions = [];
-    const params = [];
-    
-    if (filters.available_date) {
-      conditions.push('f.available_date = ?');
-      params.push(filters.available_date);
-    }
-    
-    if (filters.meal_type) {
-      conditions.push('f.meal_type = ?');
-      params.push(filters.meal_type);
-    }
-    
-    if (filters.is_available !== undefined) {
-      conditions.push('f.is_available = ?');
-      params.push(filters.is_available);
-    }
-    
-    if (conditions.length > 0) {
-      query += ' WHERE ' + conditions.join(' AND ');
-    }
-    
-    query += ' GROUP BY f.food_id ORDER BY f.available_date DESC, f.meal_type';
-    
-    const [rows] = await pool.execute(query, params);
-    return rows;
-  }
+    /**
+     * Gets all available menu items for today and the future.
+     * This query now correctly joins 'daily_food' with its components.
+     * @returns {Promise<object>} - An object containing dailyFoods and standardFoods.
+     */
+    static async getTodaysMenu() {
+        const today = new Date().toISOString().split('T')[0];
 
-  // Find food by ID
-  static async findById(food_id) {
-    const [rows] = await pool.execute(
-      `SELECT f.*, 
-              GROUP_CONCAT(DISTINCT fc.component_id SEPARATOR ', ') as component_ids,
-              GROUP_CONCAT(DISTINCT fc.component_name SEPARATOR ', ') as components
-       FROM foods f
-       LEFT JOIN daily_menu_items dmi ON f.food_id = dmi.food_id 
-       LEFT JOIN food_components fc ON dmi.component_id = fc.component_id
-       WHERE f.food_id = ?
-       GROUP BY f.food_id`,
-      [food_id]
-    );
-    return rows[0];
-  }
+        // Query 1: Get daily meal packages scheduled for today or later
+        const [dailyFoods] = await pool.execute(
+            `SELECT 
+                df.d_id, 
+                df.d_name, 
+                df.meal_type, 
+                df.meal_price,
+                GROUP_CONCAT(dfc.dfc_name SEPARATOR ', ') as components
+             FROM 
+                daily_food df
+             LEFT JOIN 
+                daily_food_daily_component dfdc ON df.d_id = dfdc.d_id
+             LEFT JOIN 
+                daily_food_component dfc ON dfdc.dfc_id = dfc.dfc_id
+             WHERE 
+                df.meal_date >= ?
+             GROUP BY
+                df.d_id
+             ORDER BY 
+                df.meal_date ASC`,
+            [today]
+        );
 
-  // Update a food item
-  static async update(food_id, foodData) {
-    const connection = await pool.getConnection();
-    try {
-      await connection.beginTransaction();
-      
-      // Update food
-      const [result] = await connection.execute(
-        `UPDATE foods 
-         SET food_name = ?, category_id = ?, price = ?, available_date = ?, 
-             meal_type = ?, is_available = ?, image_url = ?
-         WHERE food_id = ?`,
-        [foodData.food_name, foodData.category_id, foodData.price, 
-         foodData.available_date, foodData.meal_type, foodData.is_available, 
-         foodData.image_url, food_id]
-      );
-      
-      // Delete existing components
-      await connection.execute(
-        'DELETE FROM daily_menu_items WHERE food_id = ?',
-        [food_id]
-      );
-      
-      // Insert new components if provided
-      if (foodData.components && foodData.components.length > 0) {
-        for (const component_id of foodData.components) {
-          await connection.execute(
-            `INSERT INTO daily_menu_items (food_id, component_id, available_date) 
-             VALUES (?, ?, ?)`,
-            [food_id, component_id, foodData.available_date]
-          );
-        }
-      }
-      
-      await connection.commit();
-      return result;
-    } catch (error) {
-      await connection.rollback();
-      throw error;
-    } finally {
-      connection.release();
+        // Query 2: Get standard food items from the 'food' table
+        const [standardFoods] = await pool.execute(
+            `SELECT f_id, f_name, price FROM food WHERE stock > 0 AND expire_date >= ?`,
+            [today]
+        );
+
+        return { dailyFoods, standardFoods };
     }
-  }
-
-  // Delete a food item
-  static async delete(food_id) {
-    const connection = await pool.getConnection();
-    try {
-      await connection.beginTransaction();
-      
-      // Delete from daily_menu_items first
-      await connection.execute(
-        'DELETE FROM daily_menu_items WHERE food_id = ?',
-        [food_id]
-      );
-      
-      // Delete from foods
-      const [result] = await connection.execute(
-        'DELETE FROM foods WHERE food_id = ?',
-        [food_id]
-      );
-      
-      await connection.commit();
-      return result;
-    } catch (error) {
-      await connection.rollback();
-      throw error;
-    } finally {
-      connection.release();
-    }
-  }
-
-  // Get available meal types for a date
-  static async getMealTypesByDate(date) {
-    const [rows] = await pool.execute(
-      `SELECT DISTINCT meal_type 
-       FROM foods 
-       WHERE available_date = ? AND is_available = 1`,
-      [date]
-    );
-    return rows.map(row => row.meal_type);
-  }
-
-  // Get today's menu by meal type
-  static async getTodaysMenu(meal_type = null) {
-    const today = new Date().toISOString().split('T')[0];
-    let query = `
-      SELECT f.*, 
-             GROUP_CONCAT(DISTINCT fc.component_name SEPARATOR ', ') as components
-      FROM foods f
-      LEFT JOIN daily_menu_items dmi ON f.food_id = dmi.food_id 
-      LEFT JOIN food_components fc ON dmi.component_id = fc.component_id
-      WHERE f.available_date = ? AND f.is_available = 1
-    `;
-    
-    const params = [today];
-    
-    if (meal_type) {
-      query += ' AND f.meal_type = ?';
-      params.push(meal_type);
-    }
-    
-    query += ' GROUP BY f.food_id ORDER BY f.meal_type, f.food_name';
-    
-    const [rows] = await pool.execute(query, params);
-    return rows;
-  }
 }
 
 export default Food;


### PR DESCRIPTION
Refactors the menu generation and fetching logic to support a more complex canteen offering. The system now distinguishes between daily meal packages and standard a-la-carte items, combining them into a single, unified menu for the client.

- The `Food.js` model now queries `daily_food` and `food` tables to get all available items.
- The `foodController` merges daily and standard items into a single array with a consistent structure for the API response.
- The old `/api/menu` route and `menuController` have been removed in favor of this new consolidated approach.

BREAKING CHANGE: The daily menu API has been replaced. The `/api/menu` endpoint is removed. Clients must adapt to the new endpoint and the new, unified data structure for menu items.