### PR TITLE
build(deploy): add vercel deployment configuration

### DIFF
--- a/OrionXCanteen/vercel.json
+++ b/OrionXCanteen/vercel.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "build"
+      }
+    },
+    {
+      "src": "backend/server.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "backend/server.js"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "frontend/build/$1"
+    }
+  ]
+}


### PR DESCRIPTION
Introduce the `vercel.json` file to configure the project for deployment on the Vercel platform.

This configuration defines the build steps and routing for the monorepo structure:
- The `frontend` is configured for a static build.
- The `backend` is set up to run as a Node.js serverless function.
- Routes are established to direct `/api` requests to the backend and all other traffic to the frontend application.